### PR TITLE
Add support for the Hover Editor plugin

### DIFF
--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -112,13 +112,15 @@
 }
 
 // Preview embeds
-.popover .markdown-embed-content .obsidian-banner-wrapper {
-  margin-top: var(--banner-preview-embed-height);
+.popover .markdown-embed-content, .hover-editor.hover-popover .markdown-rendered {
+  .obsidian-banner-wrapper {
+    margin-top: var(--banner-preview-embed-height);
 
-  > .obsidian-banner {
-    height: var(--banner-preview-embed-height);
+    > .obsidian-banner {
+      height: var(--banner-preview-embed-height);
 
-    img { cursor: initial; }
+      img { cursor: initial; }
+    }
   }
 }
 


### PR DESCRIPTION
The Banners plugin has a nice integration with the note's preview feature. But now becoming popular a [Hover Editor](https://github.com/nothingislost/obsidian-hover-editor) plugin that allows user to use a better and most powerful note's preview solution.

This pull request provides support to the banners' plugin feature - special height for note's preview banner. With it, the Banners plugin renders height for the Hover Editor's previews too.