### PR TITLE
Header: Allow to use a string list, for frontmatter key. Use the {{syntax}} to recognize key

### DIFF
--- a/src/banner/Banner.svelte
+++ b/src/banner/Banner.svelte
@@ -63,7 +63,7 @@
   $: bannerX = x ?? 0.5;
   $: bannerY = y ?? 0.5;
   $: lockValue = lock ?? false;
-  $: headerText = getHeaderText(header, file);
+  $: headerText = getHeaderText(header, file, $settings);
   $: withBanner = !!source;
   $: isEmbed = !!embed;
 </script>

--- a/src/banner/Banner.svelte
+++ b/src/banner/Banner.svelte
@@ -15,7 +15,6 @@
   import {
     fetchImage,
     getBannerHeight,
-    getHeaderText,
     getHeights,
     getSizerHeight
   } from './utils';
@@ -24,7 +23,7 @@
   export let x = 0.5;
   export let y = 0.5;
   export let icon: IconString | undefined = undefined;
-  export let header: string | string[] | null | undefined = undefined;
+  export let header: string | undefined = undefined;
   export let lock = false;
 
   export let viewType: 'editing' | 'reading';
@@ -63,7 +62,6 @@
   $: bannerX = x ?? 0.5;
   $: bannerY = y ?? 0.5;
   $: lockValue = lock ?? false;
-  $: headerText = getHeaderText(header, file, $settings);
   $: withBanner = !!source;
   $: isEmbed = !!embed;
 </script>
@@ -94,10 +92,10 @@
       <Error {error} />
     {/await}
   {/if}
-  {#if icon || headerText}
+  {#if icon || header}
     <Header
       {icon}
-      header={headerText}
+      {header}
       {withBanner}
       {isEmbed}
       on:open-icon-modal={openIconModal}

--- a/src/banner/Banner.svelte
+++ b/src/banner/Banner.svelte
@@ -24,7 +24,7 @@
   export let x = 0.5;
   export let y = 0.5;
   export let icon: IconString | undefined = undefined;
-  export let header: string[] | null | undefined = undefined;
+  export let header: string | string[] | null | undefined = undefined;
   export let lock = false;
 
   export let viewType: 'editing' | 'reading';

--- a/src/banner/Banner.svelte
+++ b/src/banner/Banner.svelte
@@ -24,7 +24,7 @@
   export let x = 0.5;
   export let y = 0.5;
   export let icon: IconString | undefined = undefined;
-  export let header: string | null | undefined = undefined;
+  export let header: string[] | null | undefined = undefined;
   export let lock = false;
 
   export let viewType: 'editing' | 'reading';

--- a/src/banner/utils.ts
+++ b/src/banner/utils.ts
@@ -112,9 +112,8 @@ export const getHeaderText = (header: string[] | null | undefined, file: TFile):
     for (const h of header) {
       if (h === '{{alias}}' && frontmatter?.aliases) {
         return frontmatter.aliases[0];
-      } else if (h.match(/\{{(.*)\}}/)) {
-        const key = h.match(/\{{(.*)\}}/)![1];
-        if (frontmatter?.[key]) return frontmatter[key]; //note : The key must exists!
+      } else if (h.match(/\{{(.*)\}}/)&& frontmatter && frontmatter?.[h.match(/\{{(.*)\}}/)![1]]) {
+        return frontmatter[h.match(/\{{(.*)\}}/)![1]]; //note : The key must exists!
       } else if (h === '{{file}}') {
         return file.basename;
       }

--- a/src/banner/utils.ts
+++ b/src/banner/utils.ts
@@ -123,18 +123,21 @@ export const getHeaderText = (header: string[] | string | null | undefined,
   settings: BannerSettings):
   string | undefined => {
   const frontmatter = plug.app.metadataCache.getFileCache(file)?.frontmatter;
-  if (settings.headerPropertyKey && settings.headerByDefault && frontmatter) {
-    const key = settings.headerPropertyKey;
-    return getFrontMatterKey(key, frontmatter, file.basename);
+  const defautValue = settings.headerByDefault ? file.basename : undefined;
+  if (header === undefined) {
+    if (settings.headerPropertyKey) {
+      const key = settings.headerPropertyKey;
+      const defautValue = settings.headerByDefault ? file.basename : undefined;
+      return getFrontMatterKey(key, frontmatter, defautValue);
+    } if (settings.headerByDefault) return file.basename;
+    return undefined;
   }
-  if (settings.headerByDefault && header === undefined) return file.basename;
-  if (header === undefined) return undefined;
   if (header === null) return file.basename;
   /** In list it is useful to have fallback. ie if a key don't exist, use the second, etc.
    * If no key exist, it returns the header join by space
    */
   if (Array.isArray(header)) {
-    if (!frontmatter) return header.join(' ');
+    if (!frontmatter) return defautValue;
     for (const h of header) {
       const propertyKey = h.match(/\{{(.*)\}}/)?.[1];
       const frontmatterKey = getFrontMatterKey(propertyKey, frontmatter);
@@ -160,7 +163,6 @@ export const getHeaderText = (header: string[] | string | null | undefined,
       else if (keyName === 'file') header = header.replace(property, file.basename);
     }
   }
-  console.log('HEADER', header);
   return header;
 
 };

--- a/src/banner/utils.ts
+++ b/src/banner/utils.ts
@@ -107,6 +107,9 @@ export const getHeaderText = (header: string[] | string | null | undefined, file
   string | undefined => {
   if (header === undefined) return undefined;
   if (header === null) return file.basename;
+  /** In list it is useful to have fallback. ie if a key don't exist, use the second, etc.
+   * If no key exist, it returns the header join by space
+   */
   if (Array.isArray(header)) {
     const frontmatter = plug.app.metadataCache.getFileCache(file)?.frontmatter;
     if (!frontmatter) return header.join(' ');
@@ -123,7 +126,10 @@ export const getHeaderText = (header: string[] | string | null | undefined, file
     }
     return header.join(' ');
   }
-  /** Allow to use also a string to allow a "fusion" of value from the frontmatter */
+  /** Allow to use also a string to allow a "fusion" of value from the frontmatter
+   * ie: header: "{{title}} - {{author}}" ⇒ "My title - My author"
+   * useful for templating and the frontmatter title plugin
+  */
   const properties = header.match(/{{(.*?)}}/g);
   if (properties) {
     for (const property of properties) {

--- a/src/bannerData/index.ts
+++ b/src/bannerData/index.ts
@@ -76,13 +76,24 @@ export const extractBannerData = (
   frontmatter: Record<string, unknown> = {},
   file: TFile
 ): BannerData => {
-  return Object.entries(READ_MAP).reduce((data, [suffix, item]) => {
+  const bannerData = Object.entries(READ_MAP).reduce((data, [suffix, item]) => {
     const { key, transform } = item;
     const yamlKey = getYamlKey(suffix);
     const rawValue = frontmatter[yamlKey];
     data[key] = (rawValue && transform) ? transform(rawValue, file) : rawValue;
     return data;
   }, {} as Record<keyof BannerData, unknown>) as BannerData;
+  if (bannerData.header === null) {
+    bannerData.header = file.basename;
+  } else if (bannerData.header === undefined) {
+    const defaultValue = getSetting('headerByDefault') ? file.basename : undefined;
+    const propertyKey = getSetting('headerPropertyKey');
+    if (propertyKey) {
+      const propertyValue = frontmatter[propertyKey] ?? defaultValue;
+      bannerData.header = Array.isArray(propertyValue) ? propertyValue[0] : propertyValue;
+    }
+  }
+  return bannerData;
 };
 
 // Helper to extract banner data from a given file

--- a/src/bannerData/transformers.ts
+++ b/src/bannerData/transformers.ts
@@ -1,13 +1,48 @@
+import type { TFile } from 'obsidian';
+import { plug } from 'src/main';
+import { getSetting } from 'src/settings';
+import { FILENAME_KEY } from 'src/settings/structure';
 import type { IconString } from '.';
+
+type StringProperty = string | null | undefined;
 
 /* NOTE: There is a new regex known as /\p{RGI_Emoji}/v that can do emojis that are made of more
 than one emoji, but the `v` flag is not yet compatible */
 const EMOJI_REGEX = /[\p{Extended_Pictographic}\u{1F3FB}-\u{1F3FF}\u{1F9B0}-\u{1F9B3}]+/gu;
+const HEADER_KEY_REGEX = /{{(.+?)}}/g;
 
-export const extractIconFromYaml = (value: string | undefined): IconString | null => {
-  if (!value) return null;
+export const extractIconFromYaml = (value: StringProperty): IconString | undefined => {
+  if (!value) return undefined;
   const match = value.match(EMOJI_REGEX);
   return match?.length
     ? { type: 'emoji', value: match.join('\u200d') }
     : { type: 'text', value: value.slice(0, 1) };
+};
+
+const parseHeader = (value: string, file: TFile): string => (
+  value.replace(HEADER_KEY_REGEX, (match, keys: string) => {
+    let parsed: StringProperty;
+    for (const key of keys.split(',')) {
+      if (parsed) break;
+
+      const trimmedKey = key.trim();
+      if (trimmedKey === FILENAME_KEY) {
+        parsed = file.basename;
+      } else {
+        const property = plug.app.metadataCache.getFileCache(file)?.frontmatter?.[trimmedKey];
+        parsed = Array.isArray(property) ? property[0] : property;
+      }
+    }
+    return parsed || match;
+  })
+);
+
+export const extractHeaderFromYaml = (value: StringProperty, file: TFile): string | undefined => {
+  if (value === undefined) {
+    return getSetting('useHeaderByDefault')
+      ? parseHeader(getSetting('defaultHeaderValue'), file)
+      : undefined;
+  }
+  if (value === null) return undefined;
+  return parseHeader(value, file);
 };

--- a/src/editing/index.ts
+++ b/src/editing/index.ts
@@ -25,7 +25,11 @@ export const loadExtensions = () => {
 
 export const registerEditorBannerEvents = () => {
   // Refresh banner for specific setting changes
-  registerSettingChangeEvent('frontmatterField', () => {
+  registerSettingChangeEvent([
+    'frontmatterField',
+    'useHeaderByDefault',
+    'defaultHeaderValue'
+  ], () => {
     iterateMarkdownLeaves((leaf) => {
       leaf.view.editor.cm.dispatch({ effects: refreshEffect.of(null) });
     }, 'editing');

--- a/src/reading/index.ts
+++ b/src/reading/index.ts
@@ -72,7 +72,12 @@ export const loadPostProcessor = () => {
 };
 
 export const registerReadingBannerEvents = () => {
-  registerSettingChangeEvent(['frontmatterField', 'showInInternalEmbed'], rerender);
+  registerSettingChangeEvent([
+    'frontmatterField',
+    'showInInternalEmbed',
+    'useHeaderByDefault',
+    'defaultHeaderValue'
+  ], rerender);
   plug.registerEvent(plug.app.vault.on('rename', rerender));
 };
 

--- a/src/settings/Settings.svelte
+++ b/src/settings/Settings.svelte
@@ -178,7 +178,7 @@
     If a banner has no header, display the filename as the header instead.
   </span>
 </ToggleSetting>
-<InputSetting key="headerPropertyKey" numOrStr>
+<InputSetting key="headerPropertyKey">
   <span slot="name">Property as header</span>
   <span slot="description">
     Allow to use the value of a Property as the header instead of the filename.

--- a/src/settings/Settings.svelte
+++ b/src/settings/Settings.svelte
@@ -178,15 +178,14 @@
     If a banner has no header, display the filename as the header instead.
   </span>
 </ToggleSetting>
-<Depends on="headerByDefault">
-  <InputSetting key="headerPropertyKey" numOrStr>
-    <span slot="name">Property as header</span>
-    <span slot="description">
-      Allow to use the value of a Property as the header instead of the filename.
-      Leave it empty to disable this feature.
-    </span>
-  </InputSetting>
-</Depends>
+<InputSetting key="headerPropertyKey" numOrStr>
+  <span slot="name">Property as header</span>
+  <span slot="description">
+    Allow to use the value of a Property as the header instead of the filename.
+    Leave it empty to disable this feature.
+    Note that you will need to reload the file to see the changes.
+  </span>
+</InputSetting>
 
 <!-- Banner Icons -->
 <Header

--- a/src/settings/Settings.svelte
+++ b/src/settings/Settings.svelte
@@ -172,6 +172,21 @@
     </span>
   </InputSetting>
 </Depends>
+<ToggleSetting key="headerByDefault">
+  <span slot="name">Display filename as default header</span>
+  <span slot="description">
+    If a banner has no header, display the filename as the header instead.
+  </span>
+</ToggleSetting>
+<Depends on="headerByDefault">
+  <InputSetting key="headerPropertyKey" numOrStr>
+    <span slot="name">Property as header</span>
+    <span slot="description">
+      Allow to use the value of a Property as the header instead of the filename.
+      Leave it empty to disable this feature.
+    </span>
+  </InputSetting>
+</Depends>
 
 <!-- Banner Icons -->
 <Header

--- a/src/settings/Settings.svelte
+++ b/src/settings/Settings.svelte
@@ -189,6 +189,8 @@
       The default header text when the setting above is in effect for a given note. Any text is
       allowed, but you can also combine it <code>{'{{property}}'}</code> to reference a property in
       your note, as well as <code>{'{{filename}}'}</code> to use the file's name.
+      You can set multiple key as fallback with the
+      <code>{'{{property1, property2, filename}}'} syntax.</code>
     </span>
   </InputSetting>
 </Depends>

--- a/src/settings/Settings.svelte
+++ b/src/settings/Settings.svelte
@@ -172,20 +172,26 @@
     </span>
   </InputSetting>
 </Depends>
-<ToggleSetting key="headerByDefault">
-  <span slot="name">Display filename as default header</span>
+<ToggleSetting key="useHeaderByDefault">
+  <span slot="name">Display header by default</span>
   <span slot="description">
-    If a banner has no header, display the filename as the header instead.
+    Display a banner header without having to define a <code>{frontmatterField}_header</code>
+    property. This will essentially make it behave like Obsidian's native inline title feature.
+    <br />
+    You can override this setting at an individual note level by having an empty
+    <code>{frontmatterField}_header</code> property too.
   </span>
 </ToggleSetting>
-<InputSetting key="headerPropertyKey">
-  <span slot="name">Property as header</span>
-  <span slot="description">
-    Allow to use the value of a Property as the header instead of the filename.
-    Leave it empty to disable this feature.
-    Note that you will need to reload the file to see the changes.
-  </span>
-</InputSetting>
+<Depends on="useHeaderByDefault">
+  <InputSetting key="defaultHeaderValue">
+    <span slot="name">Default header value</span>
+    <span slot="description">
+      The default header text when the setting above is in effect for a given note. Any text is
+      allowed, but you can also combine it <code>{'{{property}}'}</code> to reference a property in
+      your note, as well as <code>{'{{filename}}'}</code> to use the file's name.
+    </span>
+  </InputSetting>
+</Depends>
 
 <!-- Banner Icons -->
 <Header

--- a/src/settings/components/InputSetting.svelte
+++ b/src/settings/components/InputSetting.svelte
@@ -22,10 +22,7 @@
     }
   };
 
-  $: placeholder = (
-    key === 'headerPropertyKey' ?
-      'title' : (DEFAULT_SETTINGS[key] as number)
-  ).toString();
+  $: placeholder = (DEFAULT_SETTINGS[key] as number | string).toString();
 </script>
 
 <SettingItem {key}>

--- a/src/settings/components/InputSetting.svelte
+++ b/src/settings/components/InputSetting.svelte
@@ -1,4 +1,4 @@
-<script lang="ts">
+<script lang='ts'>
   import type { HTMLInputTypeAttribute } from 'svelte/elements';
   import { DEFAULT_SETTINGS } from '../structure';
   import type { BannerSettings } from '../structure';
@@ -22,14 +22,17 @@
     }
   };
 
-  $: placeholder = (DEFAULT_SETTINGS[key] as number).toString();
+  $: placeholder = (
+    key === 'headerPropertyKey' ?
+      'title' : (DEFAULT_SETTINGS[key] as number)
+  ).toString();
 </script>
 
 <SettingItem {key}>
-  <slot slot="name" name="name" />
-  <slot slot="description" name="description" />
+  <slot slot='name' name='name' />
+  <slot slot='description' name='description' />
   <input
-    slot="setting"
+    slot='setting'
     let:value
     let:update
     {type}

--- a/src/settings/structure.ts
+++ b/src/settings/structure.ts
@@ -4,7 +4,6 @@ export type BannerDragModOption = 'None' | 'Shift' | 'Ctrl' | 'Alt' | 'Meta';
 type HeaderTextDecorOption = 'none' | 'shadow' | 'border';
 export type HeaderHorizontalAlignmentOption = 'left' | 'center' | 'right' | 'custom';
 export type HeaderVerticalAlignmentOption = 'center' | 'above' | 'edge' | 'below' | 'custom';
-export type PropertyKey = string | undefined;
 
 export interface BannerSettings {
   height: LengthValue;
@@ -25,14 +24,16 @@ export interface BannerSettings {
   headerHorizontalTransform: string;
   headerVerticalAlignment: HeaderVerticalAlignmentOption;
   headerVerticalTransform: string;
-  headerByDefault: boolean;
-  headerPropertyKey: PropertyKey;
+  useHeaderByDefault: boolean;
+  defaultHeaderValue: string;
   iconSize: LengthValue;
   useTwemoji: boolean;
   showPreviewInLocalModal: boolean;
   localModalSuggestionLimit: number;
   bannersFolder: string;
 }
+
+export const FILENAME_KEY = 'filename';
 
 export const DEFAULT_SETTINGS: BannerSettings = {
   height: 300,
@@ -53,8 +54,8 @@ export const DEFAULT_SETTINGS: BannerSettings = {
   headerHorizontalTransform: '0px',
   headerVerticalAlignment: 'edge',
   headerVerticalTransform: '0px',
-  headerByDefault: true,
-  headerPropertyKey: '',
+  useHeaderByDefault: true,
+  defaultHeaderValue: `{{${FILENAME_KEY}}}`,
   iconSize: '1.2em',
   useTwemoji: true,
   showPreviewInLocalModal: true,
@@ -67,6 +68,7 @@ export const TEXT_SETTINGS: Array<keyof BannerSettings> = [
   'headerSize',
   'headerHorizontalTransform',
   'headerVerticalTransform',
+  'defaultHeaderValue',
   'iconSize',
   'bannersFolder'
 ];

--- a/src/settings/structure.ts
+++ b/src/settings/structure.ts
@@ -4,6 +4,7 @@ export type BannerDragModOption = 'None' | 'Shift' | 'Ctrl' | 'Alt' | 'Meta';
 type HeaderTextDecorOption = 'none' | 'shadow' | 'border';
 export type HeaderHorizontalAlignmentOption = 'left' | 'center' | 'right' | 'custom';
 export type HeaderVerticalAlignmentOption = 'center' | 'above' | 'edge' | 'below' | 'custom';
+export type PropertyKey = string | undefined;
 
 export interface BannerSettings {
   height: LengthValue;
@@ -24,6 +25,8 @@ export interface BannerSettings {
   headerHorizontalTransform: string;
   headerVerticalAlignment: HeaderVerticalAlignmentOption;
   headerVerticalTransform: string;
+  headerByDefault: boolean;
+  headerPropertyKey: PropertyKey;
   iconSize: LengthValue;
   useTwemoji: boolean;
   showPreviewInLocalModal: boolean;
@@ -50,6 +53,8 @@ export const DEFAULT_SETTINGS: BannerSettings = {
   headerHorizontalTransform: '0px',
   headerVerticalAlignment: 'edge',
   headerVerticalTransform: '0px',
+  headerByDefault: true,
+  headerPropertyKey: 'title',
   iconSize: '1.2em',
   useTwemoji: true,
   showPreviewInLocalModal: true,

--- a/src/settings/structure.ts
+++ b/src/settings/structure.ts
@@ -54,7 +54,7 @@ export const DEFAULT_SETTINGS: BannerSettings = {
   headerVerticalAlignment: 'edge',
   headerVerticalTransform: '0px',
   headerByDefault: true,
-  headerPropertyKey: 'title',
+  headerPropertyKey: '',
   iconSize: '1.2em',
   useTwemoji: true,
   showPreviewInLocalModal: true,


### PR DESCRIPTION
feat(header): use a list for banner_header, allowing to use frontmatter keys

Support list and string. 
- For list: Use the first key found in the list. Otherwise, join the list with a space. 
- For string, replace the `{{key}}`, allowing to combine keys and simple value.

Key supported:
- {{file}} : Use basename
- {{anykey}} : use this key if exists. If the key is an array, use the first.

> [!NOTE] 
> For alias, automatically convert to `aliases` because Obsidian convert automatically this key if it's a string.

Also added new settings:
- Use the filename as default
- Set a property key

See #125 