### PR TITLE
More customizable banner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: "18.x"
+          node-version: "<=18.18"
 
       - name: Build plugin
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 .hotreload
 .env
 .vscode
+.idea

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -2,7 +2,7 @@
 	"id": "obsidian-banners",
 	"name": "Banners",
 	"description": "Add banner images to your notes!",
-	"version": "2.0.5-beta",
+	"version": "2.0.5-beta-custom1",
 	"minAppVersion": "1.4.11",
 	"author": "Noatpad",
 	"authorUrl": "https://github.com/noatpad/obsidian-banners",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-banners",
-  "version": "2.0.5-beta",
+  "version": "2.0.5-beta-custom1",
   "description": "Add banners to your Obsidian notes!",
   "main": "index.js",
   "scripts": {

--- a/src/banner/Banner.svelte
+++ b/src/banner/Banner.svelte
@@ -17,6 +17,10 @@
   export let y = 0.5;
   export let icon: IconString | undefined = undefined;
   export let header: string | undefined = undefined;
+  export let adjust_width: boolean | undefined = undefined;
+  export let objectFit: string | undefined = undefined;
+  export let objectPosition: string | undefined = undefined;
+  export let background: string | undefined = undefined;
   export let lock = false;
 
   export let viewType: 'editing' | 'reading';
@@ -28,6 +32,10 @@
 
   $: bannerX = x ?? 0.5;
   $: bannerY = y ?? 0.5;
+  $: imageAdjustWidthToReadableLineWidth = adjust_width ?? undefined;
+  $: imageObjectFit = objectFit ?? undefined;
+  $: imageObjectPosition = objectPosition ?? undefined;
+  $: imageBackground = background ?? undefined;
   $: lockValue = lock ?? false;
   $: withBanner = !!source;
   $: isEmbed = !!embed;
@@ -47,6 +55,10 @@
         {src}
         x={bannerX}
         y={bannerY}
+        {imageAdjustWidthToReadableLineWidth}
+        {imageObjectFit}
+        {imageObjectPosition}
+        {imageBackground}
         lock={lockValue}
         {embed}
         on:drag-banner={async ({ detail }) => updateBannerData(file, detail)}

--- a/src/banner/BannerImage.svelte
+++ b/src/banner/BannerImage.svelte
@@ -16,10 +16,14 @@
   export let src: string | null;
   export let x: number;
   export let y: number;
+  export let imageAdjustWidthToReadableLineWidth: boolean | undefined = undefined;
+  export let imageObjectFit: string | undefined = undefined;
+  export let imageObjectPosition: string | undefined = undefined;
+  export let imageBackground: string | undefined = undefined;
   export let lock: boolean;
   export let embed: Embedded;
   $: ({
-    adjustWidthToReadableLineWidth: readableWidth,
+    adjustWidthToReadableLineWidth: _readableWidth,
     bannerDragModifier,
     enableDragInInternalEmbed,
     enableDragInPopover,
@@ -31,6 +35,7 @@
   let draggable = !bannerDragModifier;
   let dragging = false;
 
+  const readableWidth = imageAdjustWidthToReadableLineWidth ?? _readableWidth;
   const hoverOn = () => { hovering = true; };
   const hoverOff = () => { hovering = false; };
   const dragStart = () => { dragging = true; };
@@ -58,7 +63,9 @@
     modKey: bannerDragModifier
   };
   $: gradient = (style === 'gradient');
-  $: objectPosStyle = `${objectPos.x * 100}% ${objectPos.y * 100}%`;
+  $: objectFitStyle = imageObjectFit;
+  $: objectPosStyle = imageObjectPosition ?? `${objectPos.x * 100}% ${objectPos.y * 100}%`;
+  $: backgroundStyle = imageBackground;
 </script>
 
 <img
@@ -68,7 +75,9 @@
   class:readable-width={readableWidth}
   class:draggable
   class:dragging
+  style:object-fit={objectFitStyle}
   style:object-position={objectPosStyle}
+  style:background={backgroundStyle}
   draggable={false}
   aria-hidden={true}
   on:mouseenter={hoverOn}

--- a/src/bannerData/index.ts
+++ b/src/bannerData/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 import type { EditorState } from '@codemirror/state';
 import { editorInfoField, parseYaml } from 'obsidian';
 import type { TFile } from 'obsidian';
@@ -22,6 +23,19 @@ export interface BannerDataWrite {
   y: number;
   icon: string;
   header: string | null;
+  adjust_width: boolean | null;
+  /**
+   * @see [MDN / CSS / object-fit]{@link https://developer.mozilla.org/ru/docs/Web/CSS/object-fit}
+   */
+  objectFit: 'contain' | 'cover' | 'fill' | 'none' | 'revert' | 'scale-down' | 'unset' | null;
+  /**
+   * @see [MDN / CSS / object-position]{@link https://developer.mozilla.org/ru/docs/Web/CSS/object-position}
+   */
+  objectPosition: 'bottom' | 'center' | 'left' | 'revert' | 'right' | 'top' | 'unset' | string | null;
+  /**
+   * @see [MDN / CSS / background]{@link https://developer.mozilla.org/ru/docs/Web/CSS/background}
+   */
+  background: string | null;
   lock: boolean;
 }
 
@@ -52,6 +66,54 @@ const READ_MAP: Record<string, ReadProperty> = {
     key: 'header',
     transform: extractHeaderFromYaml
   },
+  'adjust_width': {
+    key: 'adjust_width',
+    transform(value: boolean | string | null | undefined) {
+      if (typeof value === 'boolean') {
+        return value;
+      }
+      if (value === 'false') {
+        return false;
+      }
+      if (value === 'true') {
+        return true;
+      }
+      if (value === undefined || value === null) {
+        return undefined;
+      }
+      return Boolean(value);
+    }
+  },
+  'object-fit': {
+    key: 'objectFit',
+    transform(value: string | null | undefined) {
+      if (typeof value === 'string' && !!value) {
+        return value.toLowerCase();
+      }
+      return void 0;
+    }
+  },
+  'object-position': {
+    key: 'objectPosition',
+    transform(value: string | null | undefined) {
+      if (typeof value === 'string' && !!value) {
+        return value.toLowerCase();
+      }
+      return void 0;
+    }
+  },
+  'background': {
+    key: 'background',
+    transform(value: string | null | undefined) {
+      if (typeof value === 'string' && !!value) {
+        if (value.endsWith(';')) {
+          return value.slice(0, -1);
+        }
+        return value;
+      }
+      return void 0;
+    }
+  },
   lock: { key: 'lock' }
 } as const;
 
@@ -62,6 +124,10 @@ const WRITE_MAP: Record<keyof BannerData, string> = {
   y: 'y',
   icon: 'icon',
   header: 'header',
+  adjust_width: 'adjust_width',
+  objectFit: 'object-fit',
+  objectPosition: 'object-position',
+  background: 'background',
   lock: 'lock'
 } as const;
 

--- a/src/bannerData/index.ts
+++ b/src/bannerData/index.ts
@@ -47,6 +47,7 @@ export const MIME_TYPES: Record<string, string[]> = {
   'image/gif': ['gif'],
   'image/jpeg': ['jpg', 'jpeg', 'jpe'],
   'image/png': ['png'],
+  'image/svg+xml': ['svg'],
   'image/webp': ['webp']
 };
 export const IMAGE_EXTENSIONS = Object.values(MIME_TYPES).flat();

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
+/* eslint-disable @typescript-eslint/ban-ts-comment,max-len */
 import type { EditorView } from '@codemirror/view';
 import type { Editor } from 'obsidian';
 import type { IconString } from './bannerData';
@@ -97,6 +97,19 @@ declare global {
     y: number;
     icon: IconString;
     header: string;
+    adjust_width: boolean;
+    /**
+     * @see [MDN / CSS / object-fit]{@link https://developer.mozilla.org/ru/docs/Web/CSS/object-fit}
+     */
+    objectFit: 'contain' | 'cover' | 'fill' | 'none' | 'revert' | 'scale-down' | 'unset' | null;
+    /**
+     * @see [MDN / CSS / object-position]{@link https://developer.mozilla.org/ru/docs/Web/CSS/object-position}
+     */
+    objectPosition: 'bottom' | 'center' | 'left' | 'revert' | 'right' | 'top' | 'unset' | string | null;
+    /**
+     * @see [MDN / CSS / background]{@link https://developer.mozilla.org/ru/docs/Web/CSS/background}
+     */
+    background: string | null;
     lock: boolean;
   }
 }


### PR DESCRIPTION
* Add SVG support
* Add properties:
  * `banner_adjust_width` - local (file) version of `adjustWidthToReadableLineWidth` setting
  * `banner_object-fit` - css property `object-fit` for `.obsidian-banner > img` tag
  * `banner_object-position` - css property `object-position` for `.obsidian-banner > img` tag
  * `banner_background` - css property `background` for `.obsidian-banner > img` tag
* Fix workflow bug (same as in [backstage#21738 `Error: tsx must be loaded with --import instead of --loader`](https://github.com/backstage/backstage/issues/21738))